### PR TITLE
do not look for `financial_timestamp` in "web parameters"

### DIFF
--- a/R/set_web_parameters.R
+++ b/R/set_web_parameters.R
@@ -8,6 +8,4 @@ set_web_parameters <- function(file_path) {
 
   .GlobalEnv$project_name <- cfg$parameters$project_name
   .GlobalEnv$new_data <- cfg$parameters$new_data
-
-  .GlobalEnv$financial_timestamp <- cfg$parameters$financial_timestamp
 }


### PR DESCRIPTION
I can't think of any good reason that the "web parameters" would set the `financial_timestamp`. That should be defined by/per portfolio, and maybe enforced by the project/initiative. The current, default "web parameter" YML files do not bother setting `financial_timestamp`, so this always ends up as `NULL` anyway until it is properly set by the portfolio and/or project parameters.

https://github.com/RMI-PACTA/workflow.transition.monitor/blob/main/parameter_files/WebParameters_docker.yml https://github.com/RMI-PACTA/workflow.transition.monitor/blob/main/parameter_files/WebParameters_local.yml