### PR TITLE
remove defunct `new_data` option

### DIFF
--- a/R/set_web_parameters.R
+++ b/R/set_web_parameters.R
@@ -7,7 +7,6 @@ set_web_parameters <- function(file_path) {
   .GlobalEnv$user_results_path <- cfg$paths$user_data_location
 
   .GlobalEnv$project_name <- cfg$parameters$project_name
-  .GlobalEnv$new_data <- cfg$parameters$new_data
 
   .GlobalEnv$financial_timestamp <- cfg$parameters$financial_timestamp
 }


### PR DESCRIPTION
`new_data` has been defunct since the new/current data.prep has been implemented and it was removed from the TM workflow in https://github.com/RMI-PACTA/workflow.transition.monitor/pull/211