### PR TITLE
remove `project_name` parameter

### DIFF
--- a/R/set_web_parameters.R
+++ b/R/set_web_parameters.R
@@ -6,7 +6,6 @@ set_web_parameters <- function(file_path) {
   .GlobalEnv$template_path <- cfg$paths$template_location
   .GlobalEnv$user_results_path <- cfg$paths$user_data_location
 
-  .GlobalEnv$project_name <- cfg$parameters$project_name
   .GlobalEnv$new_data <- cfg$parameters$new_data
 
   .GlobalEnv$financial_timestamp <- cfg$parameters$financial_timestamp


### PR DESCRIPTION
`project_name` is set to be removed from the TM workflow in https://github.com/RMI-PACTA/workflow.transition.monitor/pull/207 and is a [seemingly unused, leftover parameter](https://github.com/RMI-PACTA/workflow.transition.monitor/pull/207#issue-1892998497)