### PR TITLE
pin {config} version to < 0.3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ License: MIT + file LICENSE
 Depends: 
     R (>= 3.5)
 Imports: 
-    config (< 0.3.2),
+    config (0.3.1),
     dplyr (>= 1.1.0),
     here,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ License: MIT + file LICENSE
 Depends: 
     R (>= 3.5)
 Imports: 
-    config (0.3.1),
+    config (<= 0.3.1),
     dplyr (>= 1.1.0),
     here,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ License: MIT + file LICENSE
 Depends: 
     R (>= 3.5)
 Imports: 
-    config (<= 0.3.1),
+    config (>= 0.3.3),
     dplyr (>= 1.1.0),
     here,
     jsonlite,
@@ -46,6 +46,8 @@ Suggests:
     testthat (>= 3.0.0),
     withr,
     yaml
+Remotes: 
+    rstudio/config
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ License: MIT + file LICENSE
 Depends: 
     R (>= 3.5)
 Imports: 
-    config,
+    config (< 0.3.2),
     dplyr (>= 1.1.0),
     here,
     jsonlite,


### PR DESCRIPTION
{config} version 0.3.2 started adding a `config` class to the object it returns which prevents {jsonlite} from converting it to JSON

see https://github.com/rstudio/config/issues/49

pinning {config}  to the previous version will avoid this problem, but it sounds like it's already fixed in the dev version, so once that's released on CRAN we should probably pin to "(>= 0.3.3)"