### PR TITLE
remove `project_location_ext` read-in

### DIFF
--- a/R/set_web_parameters.R
+++ b/R/set_web_parameters.R
@@ -1,7 +1,6 @@
 set_web_parameters <- function(file_path) {
   cfg <- config::get(file = file_path)
 
-  .GlobalEnv$project_location_ext <- cfg$paths$project_location_ext
   .GlobalEnv$data_location_ext <- cfg$paths$data_location_ext
   .GlobalEnv$template_path <- cfg$paths$template_location
   .GlobalEnv$user_results_path <- cfg$paths$user_data_location


### PR DESCRIPTION
This is a hold-over from the old PACTA_analysis days that is no longer used in any of our un-archived repos except here and two config files in workflow.transition.monitor (which I will remove once this is merged)

https://github.com/search?q=org%3ARMI-PACTA+project_location_ext+NOT+is%3Aarchived&type=code

- precedes https://github.com/RMI-PACTA/workflow.transition.monitor/pull/289