### PR TITLE
fix `create_portfolio_subfolders()` so it makes dirs recursively and test

### DIFF
--- a/R/create_portfolio_subfolders.R
+++ b/R/create_portfolio_subfolders.R
@@ -23,7 +23,7 @@ create_portfolio_subfolders <- function(
   locs_to_create <- file.path(project_location, folders, portfolio_name_ref_all)
 
   for (path in locs_to_create) {
-    dir.create(path = path, showWarnings = FALSE)
+    dir.create(path = path, showWarnings = FALSE, recursive = TRUE)
   }
 
   invisible(portfolio_name_ref_all)

--- a/tests/testthat/test-create_portfolio_subfolders.R
+++ b/tests/testthat/test-create_portfolio_subfolders.R
@@ -1,0 +1,19 @@
+test_that("multiplication works", {
+  portfolio_name_ref_all <- "test_port_name"
+  project_location = "test_location"
+
+  create_portfolio_subfolders(
+    portfolio_name_ref_all = portfolio_name_ref_all,
+    project_location = project_location
+  )
+
+  expected_dirs <-
+    c(
+      file.path(project_location, "00_Log_Files", portfolio_name_ref_all),
+      file.path(project_location, "30_Processed_Inputs", portfolio_name_ref_all),
+      file.path(project_location, "40_Results", portfolio_name_ref_all),
+      file.path(project_location, "50_Outputs", portfolio_name_ref_all)
+    )
+
+  expect_true(all(dir.exists(expected_dirs)))
+})


### PR DESCRIPTION
`create_portfolio_subfolders()` didn't seem to work as expected because `dir.create()` does nothing if the argument values have subdirectories, unless `recursive = TRUE`