### PR TITLE
hotfix: gracefully warn and continue of log_path not defined

### DIFF
--- a/R/write_log.R
+++ b/R/write_log.R
@@ -12,6 +12,11 @@
 
 # write error log for input portfolio - msg should be a string containing the error message
 write_log <- function(msg, file_path = .GlobalEnv$log_path, ...) {
+  if (is.null(file_path)) {
+    warning("The object `file_path` does not exist. Skipping log writing.")
+    return(invisible(NULL))
+  }
+
   composed <- paste(
     as.character(Sys.time()),
     as.character(msg),


### PR DESCRIPTION
The function `write_log` expects a `log_path` to be set in the global environment: 
https://github.com/RMI-PACTA/pacta.portfolio.utils/blob/160df1ece9ebff432b26aab63a992fffdbd2feca/R/write_log.R#L14

It is entirely possible that the calling environment does not this have this object defined in the `GlobalEnv`.
Currently, the function will error if that is the case, which is brittle behaviour. 

This minimal PR introduces a more lenient fall-back warning in case the `log_path` object doesn't exist in the Global Envrionment. 

## Context

We are shifting away from depending on any `GlobalEnv` defined objects with the `workflow.pacta` paradigm. Logging is handled in a more idiosyncratic way (writing to `STDOUT` and `STDERR` using the [logger](https://daroczig.github.io/logger/) R package).

⚠️ **Note**: This PR assures backwards compatibility with `workflow.transition.monitor`. 

## Reprex
``` r
library(pacta.portfolio.utils)

write_log("Hello World!")
#> Warning in write_log("Hello World!"): The object `file_path` does not exist.
#> Skipping log writing.

log_path <- tempdir()

write_log("Hello World!")

readLines(file.path(log_path, "error_messages.txt"))
#> [1] "2024-12-06 13:15:52.694406 Hello World!"
```

<sup>Created on 2024-12-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>