### PR TITLE
enable manual trigger of R CMD check CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 name: R-CMD-check
 


### PR DESCRIPTION
@jdhoffa curious if this will allow us to manually trigger R CMD check actions on Dependabot PRs that can't run the R CMD checks automatically and therefor require intervention just to merge them